### PR TITLE
tell Laravel that primary key is of type string

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -19,7 +19,21 @@ class Transaction extends Model
      * @var string
      */
     protected $primaryKey = 'cart_id';
+    
+    /**
+     * The data type of the auto-incrementing ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
 
+    /**
+     * Indicates if the model's ID is auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+    
     /**
      * The attributes that should be cast to native types.
      *


### PR DESCRIPTION
Otherwise Laravel tries to convert `cart_id` to integer